### PR TITLE
Add make buildall, move PRIVATE_KEY to properties.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,36 @@ sources = `find source -name '*.mc'`
 resources = `find resources -name '*.xml' | tr '\n' ':' | sed 's/.$$//'`
 device_resources = `find resources-$(DEVICE) -name '*.xml' | tr '\n' ':' | sed 's/.$$//'`
 appName = `grep entry manifest.xml | sed 's/.*entry="\([^"]*\).*/\1/'`
-PRIVATE_KEY = /Users/dsiwiec/.ssh/id_rsa_garmin.der
+parameters = ``
 
 build:
 	$(SDK_HOME)/bin/monkeyc --warn --output bin/$(appName).prg -m manifest.xml \
 	-z $(resources):$(device_resources) -u $(SDK_HOME)/bin/devices.xml \
 	-y $(PRIVATE_KEY) \
-	-p $(SDK_HOME)/bin/projectInfo.xml -d $(DEVICE) $(sources)
+	-p $(SDK_HOME)/bin/projectInfo.xml -d $(DEVICE) $(sources) $(parameters)
+
+buildall:
+	@for device in $(SUPPORTED_DEVICES_LIST); do \
+		echo "-----"; \
+		echo "Building for" $$device; \
+		device_resouces=sudo find resources-$$device -name '*.xml' | tr '\n' ':' | sed 's/.$$//' > /dev/null ; \
+    $(SDK_HOME)/bin/monkeyc --warn --output bin/$(appName)-$$device.prg -m manifest.xml \
+    -z $(resources):$(device_resources) -u $(SDK_HOME)/bin/devices.xml \
+    -y $(PRIVATE_KEY) \
+    -p $(SDK_HOME)/bin/projectInfo.xml -d $$device $(sources); \
+	done
 
 run: build
-	$(SDK_HOME)/bin/connectIQ &&\
+	@$(SDK_HOME)/bin/connectiq &&\
 	sleep 3 &&\
 	$(SDK_HOME)/bin/monkeydo bin/$(appName).prg $(DEVICE)
 
 deploy: build
-	cp bin/$(appName).prg $(DEPLOY)
+	@cp bin/$(appName).prg $(DEPLOY)
 
 package:
-	$(SDK_HOME)/bin/monkeyc --warn --output bin/$(appName).iq -m manifest.xml \
+	@$(SDK_HOME)/bin/monkeyc --warn --output bin/$(appName).iq -m manifest.xml \
 	-z $(resources):$(device_resources) -u $(SDK_HOME)/bin/devices.xml \
 	-y $(PRIVATE_KEY)
 	-p $(SDK_HOME)/bin/projectInfo.xml $(sources) -e -r
+

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ All you'll need to get started is edit the ```properties.mk``` file. Here's a de
 
 - **DEVICE** - device type you want to use for simulation (e.g. fenix3, vivoactive, epix...)
 - **SDK_HOME** - home folder of your SDK (e.g. /Users/me/connectiq-sdk-mac-1.2.9)
+- **PRIVATE_KEY** - path to your generated RSA private key for signing apps (needed since CIQ 1.3) (e.g. /home/.ssh/key/id_rsa_garmin.der)
 - **DEPLOY** - if you want to hot-deploy to your device, that's the mounted path for the APPS folder (e.g. /Volumes/GARMIN/GARMIN/APPS/)
-
+- **SUPPORTED_DEVICES_LIST** - a space-separated list of ConnectIQ device names to be used when building using ```make buildall```. The device names are the same as used in the CIQ manifest file (e.g. fenix3 fenix3_hr fenix5 fenix5s fenix5x).
 
 ## Targets
 
 - **build** - compiles the app
+- **buildall** - compiles the app separately for every device in the SUPPORTED_DEVICES_LIST, packaging appropriate resources. Make sure to have your resource folders named correctly (e.g. /resources-fenix3_hr)
 - **run** - compiles and starts the simulator
 - **deploy** - if your device is connected via USB, compile and deploy the app to the device
 - **package** - create an .iq file for app store submission

--- a/properties.mk
+++ b/properties.mk
@@ -1,3 +1,5 @@
 DEVICE = fenix3
 SDK_HOME = /Users/dsiwiec/connectiq-sdk-mac-2.1.3
 DEPLOY = /Volumes/GARMIN/GARMIN/APPS/
+SUPPORTED_DEVICES_LIST = d2bravo d2bravo_titanium fenix3 fenix3_hr fenix5 fenix5s fenix5x fenixchronos fr230 fr235 fr630 fr735xt fr920xt vivoactive vivoactive_hr
+PRIVATE_KEY = /path/to/private/key/id_rsa_garmin.der


### PR DESCRIPTION
I have added a makefile recipe to automatically build for several devices at once, using the correct resources for each device. This is very useful when sending beta versions to testers, if you support more than a handful device models.

I have also taken the liberty to move PRIVATE_KEY const to properties.mk where it belongs I think.

Updated Readme as well.

(and a little secret bonus is the parameters variable in Makefile, you can set any flag to the compiler through here for make build)
